### PR TITLE
docs : spring 문서 5개 추가

### DIFF
--- a/_posts/2022-12-29-RSPEC-2229.md
+++ b/_posts/2022-12-29-RSPEC-2229.md
@@ -4,20 +4,20 @@ tags: [java, Spring, readthis]
 ---
 
 스프링 프록시를 사용할 때, 같은 클래스 내에서 호환되지 않는 다른 "@Transactional" 메소드를 호출하는 경우(`this.aMethod()` 처럼), 런타임 에러가 발생할 수 있습니다.  
-이것은 스프링이 오직 메소드의 호출자(caller)만을 보고 있으며, 피호출자(callee)를 위한 적절한 설정을 생성할 수 없기 때문입니다.  
+이것은 스프링이 오직 메소드의 호출자(caller)만을 보고 있으며, 피호출자(callee)를 위한 적절한 설정을 생성할 수 없기 때문입니다.
 
 그러므로, 아래와 같이 동일한 클래스 내에서 특정한 경우에 대해 메소드가 다른 메소드를 호출해서는 안됩니다.
 
-|From|To|
-|---|---|
-|non-@Transactional|MANDATORY, NESTED, REQUIRED, REQUIRES_NEW|
-|MANDATORY|NESTED, NEVER, NOT_SUPPORTED, REQUIRES_NEW|
-|NESTED|NESTED, NEVER, NOT_SUPPORTED, REQUIRES_NEW|
-|NEVER|MANDATORY, NESTED, REQUIRED, REQUIRES_NEW|
-|NOT_SUPPORTED|MANDATORY, NESTED, REQUIRED, REQUIRES_NEW|
-|REQUIRED or @Transactional|NESTED, NEVER, NOT_SUPPORTED, REQUIRES_NEW|
-|REQUIRES_NEW|NESTED, NEVER, NOT_SUPPORTED, REQUIRES_NEW|
-|SUPPORTS|MANDATORY, NESTED, NEVER, NOT_SUPPORTED, REQUIRED, REQUIRES_NEW|
+| From                       | To                                                              |
+| -------------------------- | --------------------------------------------------------------- |
+| non-@Transactional         | MANDATORY, NESTED, REQUIRED, REQUIRES_NEW                       |
+| MANDATORY                  | NESTED, NEVER, NOT_SUPPORTED, REQUIRES_NEW                      |
+| NESTED                     | NESTED, NEVER, NOT_SUPPORTED, REQUIRES_NEW                      |
+| NEVER                      | MANDATORY, NESTED, REQUIRED, REQUIRES_NEW                       |
+| NOT_SUPPORTED              | MANDATORY, NESTED, REQUIRED, REQUIRES_NEW                       |
+| REQUIRED or @Transactional | NESTED, NEVER, NOT_SUPPORTED, REQUIRES_NEW                      |
+| REQUIRES_NEW               | NESTED, NEVER, NOT_SUPPORTED, REQUIRES_NEW                      |
+| SUPPORTS                   | MANDATORY, NESTED, NEVER, NOT_SUPPORTED, REQUIRED, REQUIRES_NEW |
 
 ### 규칙을 어긴 코드
 
@@ -39,6 +39,6 @@ public void actuallyDoTheThing() {
 
 If you like SONARKUBE, don't forget to give me a star. :star2:
 
-> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-2229)  
+> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-2229)
 
 > [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/2022-12-29-RSPEC-3753.md
+++ b/_posts/2022-12-29-RSPEC-3753.md
@@ -1,12 +1,12 @@
 ---
-title: '@Controller 클래스에서 @SessionAttributes 를 사용하는 경우 SessionStatus 객체의 setComplete 메소드를 호출해야 합니다.'
+title: "@Controller 클래스에서 @SessionAttributes 를 사용하는 경우 SessionStatus 객체의 setComplete 메소드를 호출해야 합니다."
 tags: [java, Spring]
 ---
 
 @SessionAttributes를 사용하는 Spring @Controller는 stateful/multi-post 형식을 처리하도록 설계되었습니다.  
 이러한 @Controller는 지정된 @SessionAttributes를 사용하여 요청 간에 서버에 데이터를 저장합니다.  
 해당 데이터는 세션이 끝나면 정리되어야 하지만 @RequestMapping 메서드에서 SessionStatus 객체에 대해 setComplete()가 호출되지 않는 한 Spring 이나 JVM 에서 해당 데이터를 정리할 수 없습니다.  
-SessionStatus 개체는 해당 메서드에 매개 변수로 전달되어야 합니다.  
+SessionStatus 개체는 해당 메서드에 매개 변수로 전달되어야 합니다.
 
 ### 규칙을 어긴 코드
 
@@ -49,6 +49,6 @@ public class HelloWorld {
 
 If you like SONARKUBE, don't forget to give me a star. :star2:
 
-> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-3753)  
+> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-3753)
 
 > [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/2022-12-29-RSPEC-4602.md
+++ b/_posts/2022-12-29-RSPEC-4602.md
@@ -8,11 +8,12 @@ tags: [java, Spring]
 두 파라미터가 모두 설정되지 않은 경우, @ComponentScan 은 주석이 달린 클래스의 패키지만을 대상으로 컴포넌트를 스캔합니다.  
 default package 에 속한 클래스에서 @ComponentScan 어노테이션을 사용하는 경우, 전체 클래스패스를 대상으로 스캔합니다.  
 전체 클래스 패스를 대상으로 컴포넌트 스캔이 진행될 경우 애플리케이션의 시작 속도가 느려지고, 스프링 프레임워크 패키지 자체를 스캔했기에 BeanDefinitionStoreException 으로 애플리케이션이 구동되지 못할 수 있습니다.  
-([참고](https://github.com/spring-projects/spring-boot/blob/725337f9765494c474f33fac3214afada4aeac04/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/ConfigurationWarningsApplicationContextInitializer.java) : package 가 org, org.springframework, 혹은 Null(default) 인 경우 warning log 를 출력함)  
+([참고](https://github.com/spring-projects/spring-boot/blob/725337f9765494c474f33fac3214afada4aeac04/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/ConfigurationWarningsApplicationContextInitializer.java) : package 가 org, org.springframework, 혹은 Null(default) 인 경우 warning log 를 출력함)
 
-따라서, 해당 Rule 은 다음과 같은 상황에서 문제를 제기합니다.  
-- @ComponentScan, @SpringBootApplication, @ServletComponentScan 어노테이션이 default package 의 클래스에서 사용될 때  
-- @ComponentScan 이 명시적으로 default package 에서 사용될 때  
+따라서, 해당 Rule 은 다음과 같은 상황에서 문제를 제기합니다.
+
+- @ComponentScan, @SpringBootApplication, @ServletComponentScan 어노테이션이 default package 의 클래스에서 사용될 때
+- @ComponentScan 이 명시적으로 default package 에서 사용될 때
 
 ### 규칙을 어긴 코드
 
@@ -49,6 +50,6 @@ public class RootBootApp {
 
 If you like SONARKUBE, don't forget to give me a star. :star2:
 
-> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-4602)  
+> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-4602)
 
 > [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/2022-12-30-RSPEC-3649.md
+++ b/_posts/2022-12-30-RSPEC-3649.md
@@ -1,0 +1,74 @@
+---
+title: 데이터베이스 쿼리는 injection 공격에 취약해서는 안됩니다.
+tags: [java, injection, cwe, spring, owasp, sans-top25, cert, hibernate, sql]
+---
+
+유저가 제공하는 URL 파라미터와 같은 데이터는, 항상 신뢰할수 없고, 손상된 데이터로 간주해야 합니다.  
+손상된 데이터를 통해 SQL 쿼리를 생성하는 것은, 쿼리의 초기 의미와는 다르게 공격자들이 특별하게 조작된 값을 삽입할 수 있게 합니다.  
+데이터베이스 쿼리 인젝션 공격이 성공하면 데이터베이스의 민감한 정보들을 읽고, 수정하고, 삭제할 수 있으며 심지어는 데이터베이스를 종료하거나, 임의의 OS 커맨드를 실행할 수 있습니다.  
+
+일반적으로, 해결책은 prepared statements 를 사용하고, SQL 쿼리 파라미터를 setString 과 같은 전용 메소드를 사용해 사용자가 제공한 데이터를 적절하게 처리한 채로 바인딩해야합니다.  
+다른 방법은 모든 파라미터를 쿼리를 생성할 때 검증하는 것입니다.  
+이것은 String 값은 원시 타입으로 변경하거나, 사용 가능한 값을 white list 로 관리하여 검증하는 것으로 달성할 수 있습니다.  
+
+이 룰은 JDBC, Java EE Entity Manager, Spring Framework, Hibernate, JDO, Android Database, Apache Torque, Apache Turbine, MyBastis, Rapidoid 를 지원합니다.
+
+### 규칙을 어긴 코드
+
+```java
+public boolean authenticate(javax.servlet.http.HttpServletRequest request, java.sql.Connection connection) throws SQLException {
+    String user = request.getParameter("user");
+    String pass = request.getParameter("pass");
+
+    String query = "SELECT * FROM users WHERE user = '" + user + "' AND pass = '" + pass + "'"; // Unsafe
+
+    // 만약 특별한 값인 "foo' OR 1=1 --" 이 user = 혹은 pass = 의 인자로 전달된다면, 인증은 바이패스됩니다.
+    // 실제로, 이 값이 유저로 전달된다면 쿼리는 다음과 같습니다.
+    // SELECT * FROM users WHERE user = 'foo' OR 1=1 --' AND pass = '...'
+    // '--' 는 SQL 의 끝 라인까지 주석이므로 쿼리는 아래와 동일합니다.
+    // SELECT * FROM users WHERE user = 'foo' OR 1=1
+    // 해당 쿼리는 아래와 동일하게 되고,
+    // SELECT * FROM users WHERE 1=1
+    // 이것은 아래의 쿼리와 같습니다.
+    // SELECT * FROM users
+
+    java.sql.Statement statement = connection.createStatement();
+    java.sql.ResultSet resultSet = statement.executeQuery(query); // 규칙을 준수하지 않은 코드
+    return resultSet.next();
+}
+```
+
+### 규칙을 준수한 해결책
+
+```java
+public boolean authenticate(javax.servlet.http.HttpServletRequest request, java.sql.Connection connection) throws SQLException {
+    String user = request.getParameter("user");
+    String pass = request.getParameter("pass");
+
+    String query = "SELECT * FROM users WHERE user = ? AND pass = ?"; // authenticate() 메소드가 이러한 상황에 여전히 무차별 공격에 취약하더라도, 안전합니다.
+
+    java.sql.PreparedStatement statement = connection.prepareStatement(query);
+    statement.setString(1, user); // 적절하게 escaped 됩니다.
+    statement.setString(2, pass);
+    java.sql.ResultSet resultSet = statement.executeQuery();
+    return resultSet.next();
+}
+```
+
+### 참고
+- [OWASP Top 10 2021 Category A3](https://owasp.org/Top10/A03_2021-Injection/) - Injection
+- [OWASP Top 10 2017 Category A1](https://owasp.org/www-project-top-ten/2017/A1_2017-Injection) - Injection
+- [MITRE, CWE-20](https://cwe.mitre.org/data/definitions/20) - Improper Input Validation
+- [MITRE, CWE-89](https://cwe.mitre.org/data/definitions/89) - Improper Neutralization of Special Elements used in an SQL Command
+- [MITRE, CWE-564](https://cwe.mitre.org/data/definitions/564) - SQL Injection: Hibernate
+- [MITRE, CWE-943](https://cwe.mitre.org/data/definitions/943) - Improper Neutralization of Special Elements in Data Query Logic
+- OWASP SQL Injection Prevention [Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
+- [CERT, IDS00-J.](https://wiki.sei.cmu.edu/confluence/x/ITdGBQ) - Prevent SQL injection
+- [SANS Top 25](https://www.sans.org/top25-software-errors/#cat1) - Insecure Interaction Between Components
+---
+
+If you like SONARKUBE, don't forget to give me a star. :star2:
+
+> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-3649)  
+
+> [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/2022-12-30-RSPEC-3649.md
+++ b/_posts/2022-12-30-RSPEC-3649.md
@@ -5,11 +5,11 @@ tags: [java, injection, cwe, spring, owasp, sans-top25, cert, hibernate, sql]
 
 유저가 제공하는 URL 파라미터와 같은 데이터는, 항상 신뢰할수 없고, 손상된 데이터로 간주해야 합니다.  
 손상된 데이터를 통해 SQL 쿼리를 생성하는 것은, 쿼리의 초기 의미와는 다르게 공격자들이 특별하게 조작된 값을 삽입할 수 있게 합니다.  
-데이터베이스 쿼리 인젝션 공격이 성공하면 데이터베이스의 민감한 정보들을 읽고, 수정하고, 삭제할 수 있으며 심지어는 데이터베이스를 종료하거나, 임의의 OS 커맨드를 실행할 수 있습니다.  
+데이터베이스 쿼리 인젝션 공격이 성공하면 데이터베이스의 민감한 정보들을 읽고, 수정하고, 삭제할 수 있으며 심지어는 데이터베이스를 종료하거나, 임의의 OS 커맨드를 실행할 수 있습니다.
 
 일반적으로, 해결책은 prepared statements 를 사용하고, SQL 쿼리 파라미터를 setString 과 같은 전용 메소드를 사용해 사용자가 제공한 데이터를 적절하게 처리한 채로 바인딩해야합니다.  
 다른 방법은 모든 파라미터를 쿼리를 생성할 때 검증하는 것입니다.  
-이것은 String 값은 원시 타입으로 변경하거나, 사용 가능한 값을 white list 로 관리하여 검증하는 것으로 달성할 수 있습니다.  
+이것은 String 값은 원시 타입으로 변경하거나, 사용 가능한 값을 white list 로 관리하여 검증하는 것으로 달성할 수 있습니다.
 
 이 룰은 JDBC, Java EE Entity Manager, Spring Framework, Hibernate, JDO, Android Database, Apache Torque, Apache Turbine, MyBastis, Rapidoid 를 지원합니다.
 
@@ -56,6 +56,7 @@ public boolean authenticate(javax.servlet.http.HttpServletRequest request, java.
 ```
 
 ### 참고
+
 - [OWASP Top 10 2021 Category A3](https://owasp.org/Top10/A03_2021-Injection/) - Injection
 - [OWASP Top 10 2017 Category A1](https://owasp.org/www-project-top-ten/2017/A1_2017-Injection) - Injection
 - [MITRE, CWE-20](https://cwe.mitre.org/data/definitions/20) - Improper Input Validation
@@ -65,10 +66,11 @@ public boolean authenticate(javax.servlet.http.HttpServletRequest request, java.
 - OWASP SQL Injection Prevention [Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
 - [CERT, IDS00-J.](https://wiki.sei.cmu.edu/confluence/x/ITdGBQ) - Prevent SQL injection
 - [SANS Top 25](https://www.sans.org/top25-software-errors/#cat1) - Insecure Interaction Between Components
+
 ---
 
 If you like SONARKUBE, don't forget to give me a star. :star2:
 
-> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-3649)  
+> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-3649)
 
 > [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/2022-12-30-RSPEC-4601.md
+++ b/_posts/2022-12-30-RSPEC-4601.md
@@ -1,0 +1,53 @@
+---
+title: '"HttpSecurity" URL 패턴은 올바르게 정렬되어있어야 합니다.'
+tags: [java, spring, owasp]
+---
+
+`HttpSecurity.authorizeRequests()` 메소드로 설정된 URL 패턴은 선언된 순서로 고려됩니다.  
+이것은 더 세부적으로 구성된 설정 앞에 덜 세부적으로 구성된 설정을 선언하는 실수를 하기 쉽게 합니다.  
+그러므로, "antMatcher" 선언의 순서를 확인할 필요가 있습니다.  
+"/**" 이 선언된 경우, 이 설정은 마지막에 선언되어야 합니다.  
+
+이 규칙은 다음과 같은 상황에서 문제를 제기합니다.
+- 패턴 앞에 **로 끝나는 패턴이 있고 시작이 동일한 경우
+  - 예 : "/page*-admin/db/**"가 "/page*-admin/*" 뒤에 있는 경우
+- 와일드카드 문자가 없는 패턴 앞에 일치하는 다른 패턴이 나옵니다. 
+  - 예 : "/page-index/db"가 "/page*/*" 뒤에 있는 경우
+
+### 규칙을 어긴 코드
+
+```java
+protected void configure(HttpSecurity http) throws Exception {
+    http.authorizeRequests()
+        .antMatchers("/resources/**", "/signup", "/about").permitAll() // 규칙을 준수한 코드
+        .antMatchers("/admin/**").hasRole("ADMIN")
+        .antMatchers("/admin/login").permitAll() // 규칙을 어긴 코드; 패턴 "/admin/login" 은 패턴 "/admin/**" 앞에 위치해야 합니다.
+        .antMatchers("/**", "/home").permitAll()
+        .antMatchers("/db/**").access("hasRole('ADMIN') and hasRole('DBA')") // 규칙을 어긴 코드; 패턴 "/db/**" 패턴 "/**" 앞에 위치해야 합니다.
+        .and().formLogin().loginPage("/login").permitAll().and().logout().permitAll();
+}
+```
+
+### 규칙을 준수한 해결책
+```java
+protected void configure(HttpSecurity http) throws Exception {
+    http.authorizeRequests()
+        .antMatchers("/resources/**", "/signup", "/about").permitAll() // 규칙을 준수한 코드
+        .antMatchers("/admin/login").permitAll()
+        .antMatchers("/admin/**").hasRole("ADMIN") // 규칙을 준수한 코드
+        .antMatchers("/db/**").access("hasRole('ADMIN') and hasRole('DBA')")
+        .antMatchers("/**", "/home").permitAll() // 규칙을 준수한 코드; "/**" 이 마지막 입니다.
+        .and().formLogin().loginPage("/login").permitAll().and().logout().permitAll();
+}
+```
+
+### 참고
+- [OWASP Top 10 2021 Category A1](https://owasp.org/Top10/A01_2021-Broken_Access_Control/) - Broken Access Control
+- [OWASP Top 10 2017 Category A6](https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration) - Security Misconfiguration
+---
+
+If you like SONARKUBE, don't forget to give me a star. :star2:
+
+> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-4601)  
+
+> [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/2022-12-30-RSPEC-4601.md
+++ b/_posts/2022-12-30-RSPEC-4601.md
@@ -6,12 +6,13 @@ tags: [java, spring, owasp]
 `HttpSecurity.authorizeRequests()` 메소드로 설정된 URL 패턴은 선언된 순서로 고려됩니다.  
 이것은 더 세부적으로 구성된 설정 앞에 덜 세부적으로 구성된 설정을 선언하는 실수를 하기 쉽게 합니다.  
 그러므로, "antMatcher" 선언의 순서를 확인할 필요가 있습니다.  
-"/**" 이 선언된 경우, 이 설정은 마지막에 선언되어야 합니다.  
+"/\*\*" 이 선언된 경우, 이 설정은 마지막에 선언되어야 합니다.
 
 이 규칙은 다음과 같은 상황에서 문제를 제기합니다.
-- 패턴 앞에 **로 끝나는 패턴이 있고 시작이 동일한 경우
-  - 예 : "/page*-admin/db/**"가 "/page*-admin/*" 뒤에 있는 경우
-- 와일드카드 문자가 없는 패턴 앞에 일치하는 다른 패턴이 나옵니다. 
+
+- 패턴 앞에 \*\*로 끝나는 패턴이 있고 시작이 동일한 경우
+  - 예 : "/page*-admin/db/\*\*"가 "/page*-admin/\*" 뒤에 있는 경우
+- 와일드카드 문자가 없는 패턴 앞에 일치하는 다른 패턴이 나옵니다.
   - 예 : "/page-index/db"가 "/page*/*" 뒤에 있는 경우
 
 ### 규칙을 어긴 코드
@@ -29,6 +30,7 @@ protected void configure(HttpSecurity http) throws Exception {
 ```
 
 ### 규칙을 준수한 해결책
+
 ```java
 protected void configure(HttpSecurity http) throws Exception {
     http.authorizeRequests()
@@ -42,12 +44,14 @@ protected void configure(HttpSecurity http) throws Exception {
 ```
 
 ### 참고
+
 - [OWASP Top 10 2021 Category A1](https://owasp.org/Top10/A01_2021-Broken_Access_Control/) - Broken Access Control
 - [OWASP Top 10 2017 Category A6](https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration) - Security Misconfiguration
+
 ---
 
 If you like SONARKUBE, don't forget to give me a star. :star2:
 
-> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-4601)  
+> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-4601)
 
 > [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/2022-12-30-RSPEC-4684.md
+++ b/_posts/2022-12-30-RSPEC-4684.md
@@ -4,9 +4,9 @@ tags: [java, spring, cwe, owasp, readthis]
 ---
 
 스프링 MVC 는 자동으로 "@RequestMapping" 으로 어노테이션이 달린 메소드의 요청 파라미터들을 빈으로 바인딩합니다.  
-이러한 자동 바인딩 기능때문에, "@RequestMapping" 으로 어노테이션된 메소드의 인자들에 예상치못한 필드들을 주입하게 될 수 있습니다.    
+이러한 자동 바인딩 기능때문에, "@RequestMapping" 으로 어노테이션된 메소드의 인자들에 예상치못한 필드들을 주입하게 될 수 있습니다.  
 영속 개체들("@Entity" 혹은 "@Document")은 데이터베이스들과 연결되고, Hibernate, JPA 또는 Spring Data MongoDB 과 같은 영속 프레임워크를 통해 자동적으로 갱신됩니다.  
-이러한 두 가지 요소들이 결합되어 악의적인 공격이 가능합니다: 만약 영속 개체가 "@RequestMapping" 으로 어노테이션된 메소드의 인자로 사용된다면, 특별하게 조작된 사용자의 인풋이 데이터베이스의 예상하지 못한 필드를 업데이트 하는 것이 가능합니다.   
+이러한 두 가지 요소들이 결합되어 악의적인 공격이 가능합니다: 만약 영속 개체가 "@RequestMapping" 으로 어노테이션된 메소드의 인자로 사용된다면, 특별하게 조작된 사용자의 인풋이 데이터베이스의 예상하지 못한 필드를 업데이트 하는 것이 가능합니다.  
 이러한 이유에서 "@Entity" 혹은 "@Document" 객체들은 "@RequestMapping" 으로 어노테이션된 메소드의 인자로 사용되는 것을 피해야 합니다.
 이 룰은 "@RequestMapping" 외에도 Spring Framework 4.3에 도입된 "@GetMapping", "@PostMapping", "@PutMapping", "@DeleteMapping", "@PatchMapping"도 고려합니다.
 
@@ -81,18 +81,21 @@ public class PurchaseOrderController {
 ```
 
 ### 예외
+
 스프링 프레임워크의 "@PathVariable" 를 통해 매개 변수에 주석을 달 때는 문제가 보고되지 않았습니다.
 ID를 통해 조회가 수행되므로 클라이언트 측에서 개체를 위조할 수 없습니다.
 
 ### 참고
+
 - [OWASP Top 10 2021 Category A8](https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/) - Software and Data Integrity Failures
 - [OWASP Top 10 2017 Category A5](https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control) - Broken Access Control
 - [MITRE, CWE-915](https://cwe.mitre.org/data/definitions/915) - Improperly Controlled Modification of Dynamically-Determined Object Attributes
 - [Two Security Vulnerabilities in the Spring Framework’s MVC by Ryan Berg and Dinis Cruz](https://o2platform.files.wordpress.com/2011/07/ounce_springframework_vulnerabilities.pdf)
+
 ---
 
 If you like SONARKUBE, don't forget to give me a star. :star2:
 
-> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-4684)  
+> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-4684)
 
 > [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/2022-12-30-RSPEC-4684.md
+++ b/_posts/2022-12-30-RSPEC-4684.md
@@ -1,0 +1,98 @@
+---
+title: 영속 개체들(Persist Entities)은 "@RequestMapping" 메소드의 인수로 사용해서는 안됩니다.
+tags: [java, spring, cwe, owasp, readthis]
+---
+
+스프링 MVC 는 자동으로 "@RequestMapping" 으로 어노테이션이 달린 메소드의 요청 파라미터들을 빈으로 바인딩합니다.  
+이러한 자동 바인딩 기능때문에, "@RequestMapping" 으로 어노테이션된 메소드의 인자들에 예상치못한 필드들을 주입하게 될 수 있습니다.    
+영속 개체들("@Entity" 혹은 "@Document")은 데이터베이스들과 연결되고, Hibernate, JPA 또는 Spring Data MongoDB 과 같은 영속 프레임워크를 통해 자동적으로 갱신됩니다.  
+이러한 두 가지 요소들이 결합되어 악의적인 공격이 가능합니다: 만약 영속 개체가 "@RequestMapping" 으로 어노테이션된 메소드의 인자로 사용된다면, 특별하게 조작된 사용자의 인풋이 데이터베이스의 예상하지 못한 필드를 업데이트 하는 것이 가능합니다.   
+이러한 이유에서 "@Entity" 혹은 "@Document" 객체들은 "@RequestMapping" 으로 어노테이션된 메소드의 인자로 사용되는 것을 피해야 합니다.
+이 룰은 "@RequestMapping" 외에도 Spring Framework 4.3에 도입된 "@GetMapping", "@PostMapping", "@PutMapping", "@DeleteMapping", "@PatchMapping"도 고려합니다.
+
+### 규칙을 어긴 코드
+
+```java
+import javax.persistence.Entity;
+
+@Entity
+public class Wish {
+    Long productId;
+    Long quantity;
+    Client client;
+}
+
+@Entity
+public class Client {
+    String clientId;
+    String name;
+    String password;
+}
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class WishListController {
+
+    @PostMapping(path = "/saveForLater")
+    public String saveForLater(Wish wish) {
+        session.save(wish);
+    }
+
+    @RequestMapping(path = "/saveForLater", method = RequestMethod.POST)
+    public String saveForLater(Wish wish) {
+        session.save(wish);
+    }
+}
+```
+
+### 규칙을 준수한 해결책
+
+```java
+public class WishDTO {
+    Long productId;
+    Long quantity;
+    Long clientId;
+}
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class PurchaseOrderController {
+
+    @PostMapping(path = "/saveForLater")
+    public String saveForLater(WishDTO wish) {
+        Wish persistentWish = new Wish();
+        // "wish" 와 "persistentWish" 을 매핑합니다.
+        [...]
+        session.save(persistentWish);
+    }
+
+    @RequestMapping(path = "/saveForLater", method = RequestMethod.POST)
+    public String saveForLater(WishDTO wish) {
+        Wish persistentWish = new Wish();
+        // "wish" 와 "persistentWish" 을 매핑합니다.
+        [...]
+        session.save(persistentWish);
+    }
+}
+```
+
+### 예외
+스프링 프레임워크의 "@PathVariable" 를 통해 매개 변수에 주석을 달 때는 문제가 보고되지 않았습니다.
+ID를 통해 조회가 수행되므로 클라이언트 측에서 개체를 위조할 수 없습니다.
+
+### 참고
+- [OWASP Top 10 2021 Category A8](https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/) - Software and Data Integrity Failures
+- [OWASP Top 10 2017 Category A5](https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control) - Broken Access Control
+- [MITRE, CWE-915](https://cwe.mitre.org/data/definitions/915) - Improperly Controlled Modification of Dynamically-Determined Object Attributes
+- [Two Security Vulnerabilities in the Spring Framework’s MVC by Ryan Berg and Dinis Cruz](https://o2platform.files.wordpress.com/2011/07/ounce_springframework_vulnerabilities.pdf)
+---
+
+If you like SONARKUBE, don't forget to give me a star. :star2:
+
+> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-4684)  
+
+> [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/2022-12-30-RSPEC-5344.md
+++ b/_posts/2022-12-30-RSPEC-5344.md
@@ -4,15 +4,17 @@ tags: [java, cwe, spring, owasp, sans-top25]
 ---
 
 사용자의 비밀번호는 평문으로 저장되서는 안되며, 보안 알고리즘을 사용하여 해시값을 생성해야합니다.
+
 - 무차별 공격에 취약해서는 안됩니다.
 - collision attacks 에 취약해서는 안됩니다. (룰 S4790 을 참고하세요.)
 - 레인보우 테이블 공격의 위험성을 줄이기 위해 솔트 값을 패스워드에 추가해야 합니다. (룰 S2053 을 참고하세요.)
 
 이 룰은 암호가 평문으로 저장되거나 무차별 공격에 취약한 해싱 알고리즘을 사용했을 때 문제를 제기합니다.  
-md5나, SHA 종류의 함수들은 해시값을 빠르게 계산할 수 있기에, 특히 GPU, FPGA 혹은 ASIC 과 같은 하드웨어 장비를 통해 무차별 대입 공격이 가능합니다.(가능한 모든 암호에 대한 전체 해시 공간을 소진하기가 쉽습니다.)    
+md5나, SHA 종류의 함수들은 해시값을 빠르게 계산할 수 있기에, 특히 GPU, FPGA 혹은 ASIC 과 같은 하드웨어 장비를 통해 무차별 대입 공격이 가능합니다.(가능한 모든 암호에 대한 전체 해시 공간을 소진하기가 쉽습니다.)  
 bcrypt, PBKDF2 혹은 argon2 와 같은 최신 패스워드 해싱 알고리즘이 권장됩니다.
 
 ### 규칙을 어긴 코드
+
 ```java
 @Override
 @Autowired
@@ -35,6 +37,7 @@ public void configureGlobal(AuthenticationManagerBuilder auth, DataSource dataSo
 ```
 
 ### 규칙을 준수한 해결책
+
 ```java
 @Autowired
 public void configureGlobal(AuthenticationManagerBuilder auth, DataSource dataSource) throws Exception {
@@ -42,13 +45,14 @@ public void configureGlobal(AuthenticationManagerBuilder auth, DataSource dataSo
         .dataSource(dataSource)
         .usersByUsernameQuery("Select * from users where username=?")
         .passwordEncoder(new BCryptPasswordEncoder());
-    
+
     // or
     auth.userDetailsService(null).passwordEncoder(new BCryptPasswordEncoder());
 }
 ```
 
 ### 참고
+
 - [OWASP Top 10 2021 Category A2](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/) - Cryptographic Failures
 - [OWASP Top 10 2021 Category A4](https://owasp.org/Top10/A04_2021-Insecure_Design/) - Insecure Design
 - [OWASP CheatSheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html) - Password Storage Cheat Sheet
@@ -61,6 +65,6 @@ public void configureGlobal(AuthenticationManagerBuilder auth, DataSource dataSo
 
 If you like SONARKUBE, don't forget to give me a star. :star2:
 
-> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-5344)  
+> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-5344)
 
 > [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/2022-12-30-RSPEC-5344.md
+++ b/_posts/2022-12-30-RSPEC-5344.md
@@ -1,0 +1,66 @@
+---
+title: 비밀번호는 평문 혹은 빠른 해싱 알고리즘을 통해 저장되지 않아야 합니다.
+tags: [java, cwe, spring, owasp, sans-top25]
+---
+
+사용자의 비밀번호는 평문으로 저장되서는 안되며, 보안 알고리즘을 사용하여 해시값을 생성해야합니다.
+- 무차별 공격에 취약해서는 안됩니다.
+- collision attacks 에 취약해서는 안됩니다. (룰 S4790 을 참고하세요.)
+- 레인보우 테이블 공격의 위험성을 줄이기 위해 솔트 값을 패스워드에 추가해야 합니다. (룰 S2053 을 참고하세요.)
+
+이 룰은 암호가 평문으로 저장되거나 무차별 공격에 취약한 해싱 알고리즘을 사용했을 때 문제를 제기합니다.  
+md5나, SHA 종류의 함수들은 해시값을 빠르게 계산할 수 있기에, 특히 GPU, FPGA 혹은 ASIC 과 같은 하드웨어 장비를 통해 무차별 대입 공격이 가능합니다.(가능한 모든 암호에 대한 전체 해시 공간을 소진하기가 쉽습니다.)    
+bcrypt, PBKDF2 혹은 argon2 와 같은 최신 패스워드 해싱 알고리즘이 권장됩니다.
+
+### 규칙을 어긴 코드
+```java
+@Override
+@Autowired
+public void configureGlobal(AuthenticationManagerBuilder auth, DataSource dataSource) throws Exception {
+    auth.jdbcAuthentication()
+        .dataSource(dataSource)
+        .usersByUsernameQuery("SELECT * FROM users WHERE username = ?")
+        .passwordEncoder(new StandardPasswordEncoder()); // 규칙을 어긴 코드
+
+    // OR
+    auth.jdbcAuthentication()
+        .dataSource(dataSource)
+        .usersByUsernameQuery("SELECT * FROM users WHERE username = ?"); // 규칙을 어긴 코드; 기본값으로 평문을 사용합니다.
+
+    // OR
+    auth.userDetailsService(...); // 규칙을 어긴 코드; 기본값으로 평문을 사용합니다.
+    // OR
+    auth.userDetailsService(...).passwordEncoder(new StandardPasswordEncoder()); // 규칙을 어긴 코드
+}
+```
+
+### 규칙을 준수한 해결책
+```java
+@Autowired
+public void configureGlobal(AuthenticationManagerBuilder auth, DataSource dataSource) throws Exception {
+    auth.jdbcAuthentication()
+        .dataSource(dataSource)
+        .usersByUsernameQuery("Select * from users where username=?")
+        .passwordEncoder(new BCryptPasswordEncoder());
+    
+    // or
+    auth.userDetailsService(null).passwordEncoder(new BCryptPasswordEncoder());
+}
+```
+
+### 참고
+- [OWASP Top 10 2021 Category A2](https://owasp.org/Top10/A02_2021-Cryptographic_Failures/) - Cryptographic Failures
+- [OWASP Top 10 2021 Category A4](https://owasp.org/Top10/A04_2021-Insecure_Design/) - Insecure Design
+- [OWASP CheatSheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html) - Password Storage Cheat Sheet
+- [OWASP Top 10 2017 Category A3](https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure) - Sensitive Data Exposure
+- [MITRE, CWE-256](https://cwe.mitre.org/data/definitions/256) - Plaintext Storage of a Password
+- [MITRE, CWE-916](https://cwe.mitre.org/data/definitions/916) - Use of Password Hash With Insufficient Computational Effort
+- [SANS Top 25](https://www.sans.org/top25-software-errors/#cat3) - Porous Defenses
+
+---
+
+If you like SONARKUBE, don't forget to give me a star. :star2:
+
+> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-5344)  
+
+> [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/2022-12-30-RSPEC-5876.md
+++ b/_posts/2022-12-30-RSPEC-5876.md
@@ -1,0 +1,46 @@
+---
+title: 유저의 인증 중에 새 세션을 생성해야합니다.
+tags: [java, cwe, spring, owasp]
+---
+
+세션 고정 공격은 정당한 사용자가 공격자가 알고 있는 세션 아이디를 사용하도록 강제할 때 발생합니다.
+고정 공격을 피하기 위해서는, 유저가 인증을 할 때 마다 새로운 세션을 생성하고, 세션이 만료될 때 기존 세션(공격자가 알고있는)을 삭제하거나 무효화하는 것이 좋은 습관입니다.
+
+### 규칙을 어긴 코드
+스프링 시큐리티 콘텍스트에서, 세션 고정 보호는 기본적으로 활성화되지만, `sessionFixation().none()` 메소드를 통해 비활성화 될 수 있습니다.
+```java
+@Override
+protected void configure(HttpSecurity http) throws Exception {
+    http.sessionManagement()
+    .sessionFixation().none(); // 규칙을 어긴 코드: 존재하는 세션이 계속 유지됩니다.
+}
+```
+
+### 규칙을 준수한 해결책
+스프링 시큐리티 콘텍스트에서, 세션 고정 보호는 다음과 같이 활성화 시킬 수 있습니다.
+```java
+@Override
+protected void configure(HttpSecurity http) throws Exception {
+    http.sessionManagement()
+    .sessionFixation().newSession(); // 규칙을 준수한 코드: 기존 세션의 Attributes 를 복사하지 않고 새로운 세션을 생성합니다.
+    
+    // or
+    
+    http.sessionManagement()
+    .sessionFixation().migrateSession(); // 규칙을 준수한 코드: 새로운 세션이 생성되면, 이전 세션은 만료되고 이전 세션의 Attributes 가 복사됩니다.
+}
+```
+
+### 참고
+- [OWASP Top 10 2021 Category A7](https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/) - Identification and Authentication Failures
+- [OWASP Top 10 2017 Category A2](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication) - Broken Authentication
+- [OWASP Sesssion Fixation](https://owasp.org/www-community/attacks/Session_fixation)
+- [MITRE, CWE-384](https://cwe.mitre.org/data/definitions/384) - Session Fixation
+
+---
+
+If you like SONARKUBE, don't forget to give me a star. :star2:
+
+> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-5876)  
+
+> [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/2022-12-30-RSPEC-5876.md
+++ b/_posts/2022-12-30-RSPEC-5876.md
@@ -7,7 +7,9 @@ tags: [java, cwe, spring, owasp]
 고정 공격을 피하기 위해서는, 유저가 인증을 할 때 마다 새로운 세션을 생성하고, 세션이 만료될 때 기존 세션(공격자가 알고있는)을 삭제하거나 무효화하는 것이 좋은 습관입니다.
 
 ### 규칙을 어긴 코드
+
 스프링 시큐리티 콘텍스트에서, 세션 고정 보호는 기본적으로 활성화되지만, `sessionFixation().none()` 메소드를 통해 비활성화 될 수 있습니다.
+
 ```java
 @Override
 protected void configure(HttpSecurity http) throws Exception {
@@ -17,21 +19,24 @@ protected void configure(HttpSecurity http) throws Exception {
 ```
 
 ### 규칙을 준수한 해결책
+
 스프링 시큐리티 콘텍스트에서, 세션 고정 보호는 다음과 같이 활성화 시킬 수 있습니다.
+
 ```java
 @Override
 protected void configure(HttpSecurity http) throws Exception {
     http.sessionManagement()
     .sessionFixation().newSession(); // 규칙을 준수한 코드: 기존 세션의 Attributes 를 복사하지 않고 새로운 세션을 생성합니다.
-    
+
     // or
-    
+
     http.sessionManagement()
     .sessionFixation().migrateSession(); // 규칙을 준수한 코드: 새로운 세션이 생성되면, 이전 세션은 만료되고 이전 세션의 Attributes 가 복사됩니다.
 }
 ```
 
 ### 참고
+
 - [OWASP Top 10 2021 Category A7](https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/) - Identification and Authentication Failures
 - [OWASP Top 10 2017 Category A2](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication) - Broken Authentication
 - [OWASP Sesssion Fixation](https://owasp.org/www-community/attacks/Session_fixation)
@@ -41,6 +46,6 @@ protected void configure(HttpSecurity http) throws Exception {
 
 If you like SONARKUBE, don't forget to give me a star. :star2:
 
-> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-5876)  
+> [원문으로 바로가기](https://rules.sonarsource.com/java/tag/spring/RSPEC-5876)
 
 > [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)


### PR DESCRIPTION
- spring 태그의 문서 5개에 대한 번역입니다.
- RSPEC-4684 는 Entity 를 Controller 의 parameter 로 바인딩 하지 않고, DTO 등을 통해 변환해서 이용해야하는 이유를 설명하여 readthis 로 태그를 달았습니다.