### PR TITLE
컨트리뷰터 목록 표기 방식 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,12 @@ jekyll serve # _site 하위의 정적 디렉토리를 localhost:4000 으로 서�
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
-<table>
-  <tr>
-    <td align="center"><a href="https://github.com/isangu"><img src="https://avatars3.githubusercontent.com/u/24788424?v=4" width="100px;" alt=""/><br /><sub><b>isangu</b></sub></a><br/></td>
-    <td align="center"><a href="https://kok202.tistory.com"><img src="https://avatars3.githubusercontent.com/u/39543643?v=4" width="100px;" alt=""/><br /><sub><b>kok202</b></sub></a><br/></td>
-    <td align="center"><a href="https://github.com/gimunlee"><img src="https://avatars0.githubusercontent.com/u/46181475?v=4" width="100px;" alt=""/><br /><sub><b>gimunlee</b></sub></a><br/></td>
-    <td align="center"><a href="https://github.com/bourbonkk"><img src="https://avatars0.githubusercontent.com/u/25188468?v=4" width="100px;" alt=""/><br /><sub><b>Allen Kim</b></sub></a><br/></td>
-    <td align="center"><a href="https://github.com/ssungwxx"><img src="https://avatars0.githubusercontent.com/u/21700738?v=4" width="100px;" alt=""/><br /><sub><b>Sungwoo Kim</b></sub></a><br/></td>
-  </tr>
-</table>
+
+
+<a href="https://github.com/kantabile/sonarkube/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=kantabile/sonarkube" />
+</a>
+
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
별건 아니지만 컨트리뷰터 목록을 일일이 추가하시는 것 같아서
혹시 아래와 같이 변경하는게 어떨지 건의드립니다.

장점은 일일히 컨트리뷰터를 추가하지 않아도 된다...
단점은 개개인의 블로그 같은 링크를 걸지 못한다

### AS-IS
<img width="706" alt="image" src="https://user-images.githubusercontent.com/25188468/220617950-1fe46661-4647-4a8f-a93e-026016702673.png">
AS-IS 소스코드
<img width="825" alt="image" src="https://user-images.githubusercontent.com/25188468/220618548-e89f8d9f-3d94-4c58-a4f9-8fb2fbec5f0d.png">


### TO-BE
<img width="384" alt="image" src="https://user-images.githubusercontent.com/25188468/220618017-628fc41a-e1bd-432c-b521-1bc76ce592f3.png">
TO-BE 소스코드 
<img width="598" alt="image" src="https://user-images.githubusercontent.com/25188468/220618676-3b16f55c-b1bc-4b32-bec5-709e1f29a3d3.png">

