### PR TITLE
RSPEC-5131,RSPEC-5135,RSPEC-2755,RSPEC-3649,RSPEC-5146

### DIFF
--- a/_posts/python/2023-02-22-RSPEC-2755.md
+++ b/_posts/python/2023-02-22-RSPEC-2755.md
@@ -1,0 +1,106 @@
+---
+title: HTTP 요청 리디렉션은 위조 공격에 노출되어서는 안됩니다.
+tags:
+- Vulnerability
+- Blocker
+- injection
+- cwe
+- owasp
+- sans-top25
+- python
+---
+
+URL 매개변수, POST 데이터 페이로드 또는 쿠키와 같은 사용자 제공 데이터는 항상 신뢰할 수 없고 오염된 것으로 간주되어야 합니다.
+ 오염된 데이터를 기반으로 HTTP 리디렉션을 수행하는 애플리케이션은 공격자가 사용자를 악성 사이트로 리디렉션하여 로그인 자격 증명을 탈취하는 등의 작업을 수행할 수 있습니다.
+
+
+이 문제는 다음와 같은 방법으로 완화될 수 있습니다.
+
+- 허용 목록에 따라 사용자가 제공한 데이터의 유효성을 검사하고 일치하지 않는 입력은 거부합니다.
+- 사용자 제공 데이터를 기반으로 리디렉션을 수행하지 않도록 애플리케이션을 재설계합니다.
+
+
+### 규칙을 어긴 코드
+[lxml](https://lxml.de/) module:
+- XML 구문 분석할 때:
+```python
+parser = etree.XMLParser() # 규칙을 어긴 코드: 기본적으로 resolve_entities는 true로 설정됩니다
+tree1 = etree.parse('ressources/xxe.xml', parser)
+root1 = tree1.getroot()
+
+parser = etree.XMLParser(resolve_entities=True) # 규칙을 어긴 코드
+tree1 = etree.parse('ressources/xxe.xml', parser)
+root1 = tree1.getroot()
+```
+- XML 유효성 검사할 때:
+```python
+parser = etree.XMLParser(resolve_entities=True) # 규칙을 어긴 코드
+treexsd = etree.parse('ressources/xxe.xsd', parser)
+rootxsd = treexsd.getroot()
+schema = etree.XMLSchema(rootxsd)
+```
+- XML 변환할 때:
+```python
+ac = etree.XSLTAccessControl(read_network=True, write_network=False)  # 규칙을 어긴 코드, read_network가 true로 설정됨/네트워크 액세스가 승인됨
+transform = etree.XSLT(rootxsl, access_control=ac)
+```
+[xml.sax](https://docs.python.org/3/library/xml.sax.html) 모듈:
+```python
+parser = xml.sax.make_parser()
+myHandler = MyHandler()
+parser.setContentHandler(myHandler)
+
+parser.setFeature(feature_external_ges, True) # 규칙을 어긴 코드
+parser.parse("ressources/xxe.xml")
+```
+
+### 규칙을 준수한 해결책
+[lxml](https://lxml.de/) module:
+- XML을 구문 분석할 때 resolve_entities 및 네트워크 액세스를 비활성화합니다:
+```python
+parser = etree.XMLParser(resolve_entities=False, no_network=True) # 규칙을 준수한 코드
+tree1 = etree.parse('ressources/xxe.xml', parser)
+root1 = tree1.getroot()
+```
+- XML 유효성 검증할 때(XMLSchema를 호출할 때 [네트워크 액세스를 완전히 비활성화할 수 없음](https://bugs.launchpad.net/lxml/+bug/1234114)에 유의하십시오):
+```python
+parser = etree.XMLParser(resolve_entities=False) # 규칙을 준수한 코드: 기본적으로 no_network는 true로 설정됩니다
+treexsd = etree.parse('ressources/xxe.xsd', parser)
+rootxsd = treexsd.getroot()
+schema = etree.XMLSchema(rootxsd) # 규칙을 준수한 코드
+```
+- XML을 변환할 때 네트워크 및 파일 시스템에 대한 액세스를 비활성화합니다:
+```python
+parser = etree.XMLParser(resolve_entities=False) # 규칙을 준수한 코드
+treexsl = etree.parse('ressources/xxe.xsl', parser)
+rootxsl = treexsl.getroot()
+
+ac = etree.XSLTAccessControl.DENY_ALL  # 규칙을 준수한 코드
+transform = etree.XSLT(rootxsl, access_control=ac) # 규칙을 준수한 코드
+```
+[xml.sax](https://docs.python.org/3/library/xml.sax.html) 모듈로 xxe 공격 방지(XXE 이외의 [다른 보안상의 이유](https://docs.python.org/3/library/xml.html#xml-vulnerabilities)로 xml.sax는 권장되지 않음):
+```python
+parser = xml.sax.make_parser()
+myHandler = MyHandler()
+parser.setContentHandler(myHandler)
+parser.parse("ressources/xxe.xml") # 규칙을 준수한 코드: 3.7.1 버전: SAX 파서는 더 이상 기본적으로 일반 외부 엔터티를 처리하지 않습니다
+
+parser.setFeature(feature_external_ges, False) # 규칙을 준수한 코드
+parser.parse("ressources/xxe.xml")
+```
+
+
+### 같이보면 좋은 자료
+- [OWASP Top 10 2021 Category A5](https://owasp.org/Top10/A05_2021-Security_Misconfiguration/) - 보안 구성 오류
+- [OWASP Top 10 2017 Category A4](https://owasp.org/www-project-top-ten/2017/A4_2017-XML_External_Entities_(XXE)) - XML 외부 엔티티(XXE)
+- [OWASP XXE Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)
+- [MITRE, CWE-611](https://cwe.mitre.org/data/definitions/611) - XML 외부 엔티티 참조를 통한 정보 노출
+- [MITRE, CWE-827](https://cwe.mitre.org/data/definitions/827) - 문서 유형 정의의 부적절한 제어
+---
+
+
+If you like SONARKUBE, don't forget to give me a star. :star2:
+
+> [원문으로 바로가기](https://rules.sonarsource.com/python/type/Vulnerability/RSPEC-2755)
+
+> [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/python/2023-02-22-RSPEC-3649.md
+++ b/_posts/python/2023-02-22-RSPEC-3649.md
@@ -1,0 +1,99 @@
+---
+title: 데이터베이스 쿼리는 인젝션 공격에 취약하지 않아야 합니다.
+tags:
+- Vulnerability
+- Blocker
+- injection
+- cwe
+- owasp
+- sans-top25
+- sql
+- python
+---
+
+URL 매개변수와 같이 사용자가 제공한 데이터는 항상 신뢰할 수 없고 오염된 것으로 간주해야 합니다. 
+공격자는 오염된 데이터에서 직접 SQL 쿼리를 생성하면 쿼리 자체의 초기 의미를 변경하는 특수하게 조작된 값을 삽입할 수 있습니다. 
+데이터베이스 쿼리 인젝션 공격이 성공하면 데이터베이스에서 중요한 정보를 읽거나 수정 또는 삭제할 수 있으며, 심지어 데이터베이스를 종료하거나 임의의 운영 체제 명령을 실행할 수도 있습니다.
+
+일반적으로 해결책은 prepared statements를 사용하고 params와 같은 전용 메서드를 사용하여 변수를 SQL 쿼리 매개변수에 바인딩하여 사용자가 제공한 데이터가 올바르게 이스케이프되도록 하는 것입니다. 
+또 다른 해결책은 쿼리를 작성하는 데 사용되는 모든 매개변수의 유효성을 검사하는 것입니다. 
+이는 문자열 값을 기본 유형으로 변환하거나 허용되는 값의 화이트리스트에 대해 유효성을 검사하여 수행할 수 있습니다.
+
+이 규칙은 sqlite3, mysql, pymysql, psycopg2, pgdb, Django ORM 및 Flask-SQLAlchemy를 지원합니다.
+
+
+### 규칙을 어긴 코드
+Flask application
+```python
+from flask import request
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import text
+from database.users import User
+
+@app.route('hello')
+def hello():
+    id = request.args.get("id")
+    stmt = text("SELECT * FROM users where id=%s" % id) # 쿼리가 사용자 입력을 기반으로 구성됩니다.
+    query = SQLAlchemy().session.query(User).from_statement(stmt) # 규칙을 어긴 코드
+    user = query.one()
+    return "Hello %s" % user.username
+```
+Django application
+```python
+from django.http import HttpResponse
+from django.db import connection
+
+def hello(request):
+    id = request.GET.get("id", "")
+    cursor = connection.cursor()
+    cursor.execute("SELECT username FROM auth_user WHERE id=%s" % id) # 규칙을 어긴 코드; 쿼리가 사용자 입력을 기반으로 구성됩니다.
+    row = cursor.fetchone()
+    return HttpResponse("Hello %s" % row[0])
+```
+
+### 규칙을 준수한 해결책
+Flask application
+```python
+from flask import request
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import text
+from database.users import User
+
+@app.route('hello')
+def hello():
+    id = request.args.get("id")
+    stmt = text("SELECT * FROM users where id=:id")
+    query = SQLAlchemy().session.query(User).from_statement(stmt).params(id=id) # 규칙을 준수한 코드
+    user = query.one()
+    return "Hello %s" % user.username
+```
+
+Django application
+```python
+from django.http import HttpResponse
+from django.db import connection
+
+def hello(request):
+    id = request.GET.get("id", "")
+    cursor = connection.cursor()
+    cursor.execute("SELECT username FROM auth_user WHERE id=:id", {"id": id}) # 규칙을 준수한 코드
+    row = cursor.fetchone()
+    return HttpResponse("Hello %s" % row[0])
+```
+
+
+### 같이보면 좋은 자료
+- [OWASP Top 10 2021 Category A3](https://owasp.org/Top10/A03_2021-Injection/) - 인젝션
+- [OWASP Top 10 2017 Category A1](https://owasp.org/www-project-top-ten/2017/A1_2017-Injection) - 인젝션
+- [MITRE, CWE-20](https://cwe.mitre.org/data/definitions/20) - 잘못된 입력 유효성 검사
+- [MITRE, CWE-89](https://cwe.mitre.org/data/definitions/89) - SQL 명령에 사용된 특수 요소의 부적절한 중화
+- OWASP SQL 인젝션 예방 [치트 시트](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
+- [SANS Top 25](https://www.sans.org/top25-software-errors/#cat1) - 구성 요소 간의 안전하지 않은 상호 작용
+---
+
+
+If you like SONARKUBE, don't forget to give me a star. :star2:
+
+> [원문으로 바로가기](https://rules.sonarsource.com/python/type/Vulnerability/RSPEC-3649)
+
+> [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/python/2023-02-22-RSPEC-5131.md
+++ b/_posts/python/2023-02-22-RSPEC-5131.md
@@ -1,0 +1,94 @@
+---
+title: HTTP 요청 리디렉션은 위조 공격에 노출되어서는 안됩니다.
+tags:
+- Vulnerability
+- Blocker
+- injection
+- cwe
+- owasp
+- sans-top25
+- python
+---
+
+URL 매개변수, POST 데이터 페이로드 또는 쿠키와 같은 사용자 제공 데이터는 항상 신뢰할 수 없고 오염된 것으로 간주해야 합니다. 
+또한 웹 서버는 HTTP 요청을 처리할 때 사용자가 제공한 데이터를 사용자에게 다시 전송되는 HTTP 응답 본문으로 복사할 수 있습니다. 
+이러한 동작을 "리플렉션"이라고 합니다. 오염된 데이터를 반영하는 엔드포인트를 통해 공격자는 결국 사용자의 브라우저에서 실행될 코드를 삽입할 수 있습니다. 
+이를 통해 민감한 정보에 액세스/수정하거나 다른 사용자를 사칭하는 등 다양하고 심각한 공격이 가능해질 수 있습니다.
+
+일반적으로 해결책은 다음 중 하나입니다:
+
+- 화이트리스트를 기반으로 사용자가 제공한 데이터의 유효성을 검사하고 허용되지 않은 입력은 거부합니다.
+- 악의적인 목적으로 사용될 수 있는 모든 문자로부터 사용자 제공 데이터를 실행되지 않도록 적절하게 치환합니다.
+- 사용자가 제공한 데이터가 HTTP 응답에 다시 반영될 때 인코딩합니다. 예를 들어 HTML 콘텐츠에는 HTML 인코딩을, 속성 값에는 HTML 속성 인코딩을, 서버에서 생성된 JavaScript에는 JavaScript 인코딩을 사용하도록 출력 컨텍스트에 맞게 인코딩을 조정합니다.
+데이터를 실행되지 않도록 적절하게 치환하거나 인코딩할 때는 보안 목적으로 특별히 설계된 라이브러리만 사용하는 것이 좋습니다. 또한 사용 중인 라이브러리가 적극적으로 유지 관리되고 있는지, 최근에 발견된 취약점을 최신 상태로 유지하고 있는지 확인하세요.
+
+
+### 규칙을 어긴 코드
+
+```python
+templates/xss_shared.html
+
+<!doctype html>
+<title>Hello from Flask</title>
+{% if name %}
+  <h1>Hello {{ name }}!</h1>
+{% else %}
+  <h1>Hello, World!</h1>
+{% endif %}
+
+xss.py
+from flask import request, make_response
+
+@xss.route('/insecure/no_template_engine_replace', methods =['GET'])
+def no_template_engine_replace():
+    param = request.args.get('param', 'not set')
+
+    html = open('templates/xss_shared.html').read()
+    response = make_response(html.replace('{{ name }}', param)) # 규칙을 준수하지 않은 코드: param이 적절하게 치환되지 않습니다
+    return response
+```
+
+### 규칙을 준수한 해결책
+
+```python
+templates/xss_shared.html
+
+<!doctype html>
+<title>Hello from Flask</title>
+{% if name %}
+  <h1>Hello {{ name }}!</h1>
+{% else %}
+  <h1>Hello, World!</h1>
+{% endif %}
+
+xss.py
+from flask import request, make_response
+from markuptsafe import Markup
+
+@xss.route('/secure/no_template_engine_sanitized_Markup_escape', methods =['GET'])
+def no_template_engine_sanitized_Markup_escape():
+    param = request.args.get('param', 'not set')
+
+    param = Markup.escape(param)
+
+    html = open('templates/xss_shared.html').read()
+    response = make_response(html.replace('{{ name }}', param )) # 규칙을 준수한 코드: 'param'은 Markup.escape에 의해 치환됩니다
+    return response
+
+```
+
+
+### 같이보면 좋은 자료
+- [OWASP Top 10 2021 Category A3](https://owasp.org/Top10/A03_2021-Injection/) - 인젝션
+- [OWASP Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html) - XSS 예방 치트 시트
+- [OWASP Top 10 2017 Category A7](https://owasp.org/www-project-top-ten/2017/A7_2017-Cross-Site_Scripting_(XSS)) - 크로스-사이트 스크립팅 (XSS)
+- [MITRE, CWE-79](https://cwe.mitre.org/data/definitions/79) - 웹 페이지 생성 중 입력의 부적절한 중화 ('Cross-site Scripting')
+- [SANS Top 25](https://www.sans.org/top25-software-errors/#cat1) - 구성 요소 간의 불안정한 상호 작용
+---
+
+
+If you like SONARKUBE, don't forget to give me a star. :star2:
+
+> [원문으로 바로가기](https://rules.sonarsource.com/python/type/Vulnerability/RSPEC-5131)
+
+> [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/python/2023-02-22-RSPEC-5135.md
+++ b/_posts/python/2023-02-22-RSPEC-5135.md
@@ -1,0 +1,71 @@
+---
+title: 역직렬화는 인젝션 공격에 취약하지 않아야 합니다.
+tags:
+- Vulnerability
+- Blocker
+- injection
+- cwe
+- owasp
+- sans-top25
+- python
+---
+
+URL 매개변수, POST 데이터 페이로드 또는 쿠키와 같은 사용자가 제공한 데이터는 항상 신뢰할 수 없고 오염된 것으로 간주해야 합니다. 사용자가 제공한 데이터를 기반으로 역직렬화하면 두 가지 유형의 공격이 발생할 수 있습니다:
+- 원격 코드 실행 공격: 직렬화된 데이터의 구조를 변경하여 직렬화되지 않은 객체의 동작을 수정하는 공격입니다.
+- 매개변수 변조 공격: 권한을 상승시키거나 제품의 수량이나 가격 등을 변경하기 위해 데이터를 수정하는 공격입니다.
+
+역직렬화 공격으로부터 보호하는 가장 좋은 방법은 애플리케이션에서 역직렬화 메커니즘의 사용에 이의를 제기하는 것입니다.
+역직렬화 메커니즘의 사용이 정당화되지 않아 침해가 발생한 경우입니다(CVE-2017-9785).
+
+역직렬화 메커니즘을 사용하는 것이 상황에 맞는 경우 다음 중 한 가지 방법으로 문제를 완화할 수 있습니다:
+- [pickle](https://docs.python.org/3/library/pickle.html) 모듈은 안전하지 않으므로 신뢰할 수 없는 데이터를 역직렬화하는데 사용하지 마세요.
+- 기본 안전 로더와 함께 [PyYAML](https://pyyaml.org/wiki/PyYAMLDocumentation) 모듈만 사용하세요.
+- 기본 데이터 교환 형식을 사용하는 대신 형식이 지정되지 않은 JSON 또는 Google 프로토콜 버퍼와 같은 구조화된 데이터 접근 방식과 같은 안전한 표준 형식을 사용하세요.
+- 무결성이 손상되지 않도록 직렬화된 데이터에 역직렬화 전에 유효성을 검사하는 디지털 서명(HMAC)을 추가합니다(클라이언트가 직렬화된 데이터를 수정할 필요가 없는 경우에만 유효함).
+- 최후의 수단으로, 특정 화이트리스트 클래스에만 역직렬화가 가능하도록 제한하세요.
+
+
+### 규칙을 어긴 코드
+```python
+from flask import request
+import pickle
+import yaml
+
+@app.route('/pickle')
+def pickle_loads():
+    file = request.files['pickle']
+    pickle.load(file) # 규칙을 어긴 코드; 피클 모듈을 사용하여 사용자 입력을 역직렬화하지 마십시오.
+
+@app.route('/yaml')
+def yaml_load():
+    data = request.GET.get("data")
+    yaml.load(data, Loader=yaml.Loader) # 규칙을 어긴 코드; 안전하지 않은 yaml.Loader와 함께 yaml.load를 사용하지 마십시오.
+```
+
+### 규칙을 준수한 해결책
+```python
+from flask import request
+import yaml
+
+@app.route('/yaml')
+def yaml_load():
+    data = request.GET.get("data")
+    yaml.load(data) # 규칙을 준수한 코드;  기본 세이프 로더와 함께 yaml.load 사용을 선호합니다.
+```
+
+
+
+### 같이보면 좋은 자료
+- [OWASP Top 10 2021 Category A8](https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/) - 소프트웨어 및 데이터 무결성 실패
+- [OWASP Top 10 2017 Category A8](https://owasp.org/www-project-top-ten/2017/A8_2017-Insecure_Deserialization) - 안전하지 않은 역직렬화
+- [MITRE, CWE-20](https://cwe.mitre.org/data/definitions/20) - 부적절한 입력 검증
+- [MITRE, CWE-502](https://cwe.mitre.org/data/definitions/502) - 신뢰할 수 없는 데이터의 역직렬화
+- [SANS Top 25](https://www.sans.org/top25-software-errors/#cat2) - 위험한 리소스 관리
+---
+
+
+If you like SONARKUBE, don't forget to give me a star. :star2:
+
+> [원문으로 바로가기](https://rules.sonarsource.com/python/type/Vulnerability/RSPEC-5135)
+
+> [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/python/2023-02-22-RSPEC-5146.md
+++ b/_posts/python/2023-02-22-RSPEC-5146.md
@@ -1,0 +1,95 @@
+---
+title: HTTP 요청 리디렉션은 위조 공격에 노출되어서는 안됩니다.
+tags:
+- Vulnerability
+- Blocker
+- injection
+- cwe
+- owasp
+- sans-top25
+- python
+---
+
+URL 매개변수, POST 데이터 페이로드 또는 쿠키와 같은 사용자 제공 데이터는 항상 신뢰할 수 없고 오염된 것으로 간주되어야 합니다.
+ 오염된 데이터를 기반으로 HTTP 리디렉션을 수행하는 애플리케이션은 공격자가 사용자를 악성 사이트로 리디렉션하여 로그인 자격 증명을 탈취하는 등의 작업을 수행할 수 있습니다.
+
+
+이 문제는 다음와 같은 방법으로 완화될 수 있습니다.
+
+- 허용 목록에 따라 사용자가 제공한 데이터의 유효성을 검사하고 일치하지 않는 입력은 거부합니다.
+- 사용자 제공 데이터를 기반으로 리디렉션을 수행하지 않도록 애플리케이션을 재설계합니다.
+
+
+### 규칙을 어긴 코드
+Flask
+```python
+from flask import request, redirect, Response
+
+@app.route('flask_redirect')
+def flask_redirect():
+    url = request.args["next"]
+    return redirect(url)  # Noncompliant
+
+@app.route('set_location_header')
+def set_location_header():
+    url = request.args["next"]
+    response = Response("redirecting...", 302)
+    response.headers['Location'] = url  # 규칙을 어긴 코드
+    return response
+```
+Django
+```python
+from django.http import HttpResponseRedirect
+
+def http_responser_redirect(request):
+    url = request.GET.get("next", "/")
+    return HttpResponseRedirect(url)  # 규칙을 어긴 코드
+
+def set_location_header(request):
+    url = request.GET.get("next", "/")
+    response = HttpResponse(status=302)
+    response['Location'] = url  # 규칙을 어긴 코드
+    return response
+```
+
+### 규칙을 준수한 해결책
+Flask
+```python
+from flask import request, redirect, Response, url_for
+
+@app.route('flask_redirect')
+def flask_redirect():
+    endpoint = request.args["next"]
+    return redirect(url_for(endpoint))
+```
+
+Django
+```python
+from django.http import HttpResponseRedirect
+from urllib.parse import urlparse
+
+DOMAINS_WHITELIST = ['www.example.com', 'example.com']
+
+def http_responser_redirect(request):
+    url = request.GET.get("next", "/")
+    parsed_uri = urlparse(url)
+    if parsed_uri.netloc in DOMAINS_WHITELIST:
+        return HttpResponseRedirect(url)
+    return HttpResponseRedirect("/")
+```
+
+
+### 같이보면 좋은 자료
+- [OWASP Top 10 2021 Category A1](https://owasp.org/Top10/A01_2021-Broken_Access_Control/) - 손상된 액세스 제어
+- [OWASP Top 10 2017 Category A5](https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control) - 손상된 액세스 제어
+- [MITRE, CWE-20](https://cwe.mitre.org/data/definitions/20) - 부적절한 입력 검증
+- [MITRE, CWE-601](https://cwe.mitre.org/data/definitions/601) - 신뢰할 수 없는 사이트로의 URL 리디렉션('Open Redirect')
+- [SANS Top 25](https://www.sans.org/top25-software-errors/#cat2) - 위험한 리소스 관리
+---
+
+
+If you like SONARKUBE, don't forget to give me a star. :star2:
+
+> [원문으로 바로가기](https://rules.sonarsource.com/python/type/Vulnerability/RSPEC-5146)
+
+> [![Star This Project](https://img.shields.io/github/stars/kantabile/sonarkube.svg?label=Stars&style=social)](https://github.com/kantabile/sonarkube)

--- a/_posts/python/2023-02-22-RSPEC-5146.md
+++ b/_posts/python/2023-02-22-RSPEC-5146.md
@@ -28,7 +28,7 @@ from flask import request, redirect, Response
 @app.route('flask_redirect')
 def flask_redirect():
     url = request.args["next"]
-    return redirect(url)  # Noncompliant
+    return redirect(url)  # 규칙을 어긴 코드
 
 @app.route('set_location_header')
 def set_location_header():


### PR DESCRIPTION
논의하고 싶은 부분

1. Sanitize -> 보안쪽을 하다보니 이 단어가 많이 나옵니다. 예를 들어 사용자 입력으로 <script></script>와 같은 문자열이들어왔을때 이것을 %3Cscript%3E%3C/script%3E 이렇게 바꿔주는 작업을 이야기합니다. 번역기를 돌려보면 살균하다 라고 나오는데 .. 저는 그냥 "실행되지 않도록 적절하게 치환합니다" 라고 표현했습니다. 조금더 간결한 표현이 없을까요?
예시)
`
Sanitize user-provided data from any characters that can be used for malicious purposes.
`

2. 두 가지 였는데, 1번을 적으면서 까먹었습니다. 잠이 부족한가 보네요 ..

보안쪽은 문장이 굉장히 많네요. 오늘은 [deepl](https://www.deepl.com/translator#en/ko/by%20default%20resolve_entities%20is%20set%20to%20true)의 힘을 빌어서 작업해봤습니다.


요즘 [go-druid](https://github.com/grafadruid/go-druid) 여기에 살짝 한눈을 좀 팔았습니다. 수정할 부분이 많아서 PR을 몇개 날렸는데 외국인들은 정말 느리네요. 😭 
